### PR TITLE
Changing from optparse (deprecated) to argparse module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,17 @@ Usage example:
 
  - UNIX:
 
-`       python fetchFromGoogleCloud.py -s 203031 -b OLI_TIRS -d 20150101 -f 20150630 -c 30 --output ~/LANDSAT --outputcatalogs /tmp`
+`       python fetchFromGoogleCloud.py 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 --output ~/LANDSAT --outputcatalogs /tmp`
 
-`       python fetchFromGoogleCloud.py -s 44UPU -b S2 -d 20161001 -f 20161231 --output ~/SENTINEL2 --outputcatalogs /tmp`
+`       python fetchFromGoogleCloud.py 44UPU S2 2016-10-01 2016-12-31 --output ~/SENTINEL2 --outputcatalogs /tmp`
 
  - WINDOWS:
 
-`       python fetchFromGoogleCloud.py -s 203031 -b OLI_TIRS -d 20150101 -f 20150630 -c 30 --output %TEMP%\LANDSAT --outputcatalogs %TEMP%\LANDSAT`
+`       python fetchFromGoogleCloud.py 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 --output %TEMP%\LANDSAT --outputcatalogs %TEMP%\LANDSAT`
 
-`       python fetchFromGoogleCloud.py -s 44UPU -b S2 -d 20161001 -f 20161231 --output %TEMP%\SENTINEL2 --outputcatalogs %TEMP%\SENTINEL2`
+`       python fetchFromGoogleCloud.py 44UPU S2 2016-10-01 2016-12-31 --output %TEMP%\SENTINEL2 --outputcatalogs %TEMP%\SENTINEL2`
 
-Options:
-
-`         -h, --help            show this help message and exit`
-
-`         -s SCENE, --scene=SCENE               WRS2 coordinates of scene (ex 198030)`
-
-`         -d START_DATE, --start_date=START_DATE start date, fmt('20131223')`
-
-`         -f END_DATE, --end_date=END_DATE      end date, fmt('20131223')`
-
-`         -c CLOUDS, --cloudcover=CLOUDS        Set a limit to the cloud cover of the image`
-
-`         -b BIRD, --sat=BIRD                   Which satellite are you looking for. Available options are: TM, ETM, OLI_TIRS, S2`
-
-`         --output=OUTPUT                       Where to download files`
-
-`         --outputcatalogs=OUTPUTCATALOGS       Where to download metadata catalog files`
+Run the script with -h switch for more help usage.
 
 Compatible with python 2.7 and 3.x.
 


### PR DESCRIPTION
Apart from changing from optparse to argparse, I removed the script examples from the python script (left it on README though), not sure if you mind that or not...
Changed some parameters from optional to required, so some flags are not needed, since the required parameters are supposed to follow an expected sequence. Updated README accordingly with the new syntax for the command line.