### PR TITLE
fix to support Py3 and provide gdal dependency through conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,19 @@ Once found, it downloads the image files.
 
 Small demo video: https://youtu.be/8zCs0nxl-rU
 
-Install:
+You may either install the package through pip:
 
 `       pip install fels`
 
+or if using a conda environment, the following steps are recommended to create and install dependencies:
+`       conda create --name fetchLSGC python=3.6 numpy`
+Switch to the new environment (`source activate fetchLSGC` in Linux), and install the gdal dependency from conda-forge
+`       conda config --add channels conda-forge`
+`       conda install gdal`
+
 Usage examples:
 
- - UNIX:
+ - LINUX:
 
 `       python fetchFromGoogleCloud.py 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 -o ~/LANDSAT --latest --outputcatalogs /tmp`
 

--- a/fetchFromGoogleCloud.py
+++ b/fetchFromGoogleCloud.py
@@ -10,7 +10,7 @@ import glob
 if sys.version_info[0] < 3:
     import urllib
 else:
-    import urllib.request
+    import urllib.request as urllib
 import gzip
 try:
     from osgeo import gdal
@@ -29,10 +29,7 @@ def downloadMetadataFile(url, outputdir, program, verbose=False):
         # download the file
         try:
             if not os.path.exists(theZippedFile):
-                if sys.version_info[0] < 3:
-                    urllib.urlretrieve(url, filename=theZippedFile)
-                else:
-                    urllib.request.urlretrieve(url, filename=theZippedFile)
+                urllib.urlretrieve(url, filename=theZippedFile)
         except:
             print("Some error occurred when trying to download the Metadata file!")
     if not os.path.isfile(theFile):
@@ -144,10 +141,7 @@ def downloadLandsatFromGoogleCloud(url, outputdir, verbose=False, overwrite=Fals
                 os.makedirs(destinationDir)
                 destinationFile = os.path.join(destinationDir, img + "_" + bands)
                 try:
-                    if sys.version_info[0] < 3:
-                        urllib.urlretrieve(completeUrl, filename=destinationFile)
-                    else:
-                        urllib.request.urlretrieve(completeUrl, filename=destinationFile)
+                    urllib.urlretrieve(completeUrl, filename=destinationFile)
                 except:
                     os.remove(destinationFile)
                     continue
@@ -165,10 +159,7 @@ def downloadS2FromGoogleCloud(url, outputdir, verbose=False, overwrite=False, pa
     destinationManifestFile = os.path.join(destinationDir, "manifest.safe")
     if not os.path.exists(destinationDir) or overwrite:
         os.makedirs(destinationDir)
-        if sys.version_info[0] < 3:
-            urllib.urlretrieve(manifest, filename=destinationManifestFile)
-        else:
-            urllib.request.urlretrieve(manifest, filename=destinationManifestFile)
+        urllib.urlretrieve(manifest, filename=destinationManifestFile)
         with open(destinationManifestFile, 'r') as readManifestFile:
             tempList = readManifestFile.read().split()
         p = 0
@@ -197,10 +188,7 @@ def downloadS2FromGoogleCloud(url, outputdir, verbose=False, overwrite=False, pa
                     # downloading files
                     destinationFile = destinationDir + completeUrl
                     try:
-                        if sys.version_info[0] < 3:
-                            urllib.urlretrieve(url + completeUrl, filename=destinationFile)
-                        else:
-                            urllib.request.urlretrieve(url + completeUrl, filename=destinationFile)
+                        urllib.urlretrieve(url + completeUrl, filename=destinationFile)
                     except:
                         continue
         granule = os.path.dirname(os.path.dirname(get_S2_image_bands(destinationDir, "B01")))

--- a/fetchFromGoogleCloud.py
+++ b/fetchFromGoogleCloud.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import csv
 import datetime
@@ -129,10 +130,8 @@ def downloadLandsatFromGoogleCloud(url, outputdir, verbose=False, overwrite=Fals
         p += 1
         percent = int(p * 100 / len(possible_bands))
         if percent > 100: percent = 100
-        print("%2d%%" % percent,)
-        if percent < 100:
-            print("\b\b\b\b\b",)  # Erase "NN% "
-        else:
+        print("%2d%%" % percent, end='\r')
+        if percent >= 100:
             print("Done.")
         for bands in possible_bands:
             completeUrl = url + "/" + img + "_" + bands

--- a/fetchFromGoogleCloud.py
+++ b/fetchFromGoogleCloud.py
@@ -7,7 +7,10 @@ import sys
 import tempfile
 import shutil
 import glob
-import urllib
+if sys.version_info[0] < 3:
+    import urllib
+else:
+    import urllib.request
 import gzip
 try:
     from osgeo import gdal
@@ -26,7 +29,10 @@ def downloadMetadataFile(url, outputdir, program, verbose=False):
         # download the file
         try:
             if not os.path.exists(theZippedFile):
-                urllib.urlretrieve(url, filename=theZippedFile)
+                if sys.version_info[0] < 3:
+                    urllib.urlretrieve(url, filename=theZippedFile)
+                else:
+                    urllib.request.urlretrieve(url, filename=theZippedFile)
         except:
             print("Some error occurred when trying to download the Metadata file!")
     if not os.path.isfile(theFile):
@@ -138,7 +144,10 @@ def downloadLandsatFromGoogleCloud(url, outputdir, verbose=False, overwrite=Fals
                 os.makedirs(destinationDir)
                 destinationFile = os.path.join(destinationDir, img + "_" + bands)
                 try:
-                    urllib.urlretrieve(completeUrl, filename=destinationFile)
+                    if sys.version_info[0] < 3:
+                        urllib.urlretrieve(completeUrl, filename=destinationFile)
+                    else:
+                        urllib.request.urlretrieve(completeUrl, filename=destinationFile)
                 except:
                     os.remove(destinationFile)
                     continue
@@ -156,7 +165,10 @@ def downloadS2FromGoogleCloud(url, outputdir, verbose=False, overwrite=False, pa
     destinationManifestFile = os.path.join(destinationDir, "manifest.safe")
     if not os.path.exists(destinationDir) or overwrite:
         os.makedirs(destinationDir)
-        urllib.urlretrieve(manifest, filename=destinationManifestFile)
+        if sys.version_info[0] < 3:
+            urllib.urlretrieve(manifest, filename=destinationManifestFile)
+        else:
+            urllib.request.urlretrieve(manifest, filename=destinationManifestFile)
         with open(destinationManifestFile, 'r') as readManifestFile:
             tempList = readManifestFile.read().split()
         p = 0
@@ -185,7 +197,10 @@ def downloadS2FromGoogleCloud(url, outputdir, verbose=False, overwrite=False, pa
                     # downloading files
                     destinationFile = destinationDir + completeUrl
                     try:
-                        urllib.urlretrieve(url + completeUrl, filename=destinationFile)
+                        if sys.version_info[0] < 3:
+                            urllib.urlretrieve(url + completeUrl, filename=destinationFile)
+                        else:
+                            urllib.request.urlretrieve(url + completeUrl, filename=destinationFile)
                     except:
                         continue
         granule = os.path.dirname(os.path.dirname(get_S2_image_bands(destinationDir, "B01")))


### PR DESCRIPTION
fixing urllib import to support both Python 2 and Python 3, and provides instructions on how to install GDAL through conda-forge. Fixes #29 