### PR TITLE
Fix for raising exceptions

### DIFF
--- a/fetchFromGoogleCloud.py
+++ b/fetchFromGoogleCloud.py
@@ -16,9 +16,10 @@ import gzip
 try:
     from osgeo import gdal
 except ImportError:
-    raise (""" ERROR: Could not find the GDAL/OGR Python library bindings.
+    raise ModuleNotFoundError(""" ERROR: Could not find the GDAL/OGR Python library bindings.
                On Debian based systems you can install it with this command:
-               apt install python-gdal""")
+               apt install python-gdal
+               """)
 
 
 def downloadMetadataFile(url, outputdir, program, verbose=False):


### PR DESCRIPTION
Fixes issue #34. Python is a bit odd and will show the last line of the exception when it occurs, so the newline is there so that the user doesn't see `apt install python-gdal""")` in the backtrace.