### PR TITLE
Avoid empty folders when the internet speed is unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Usage examples:
 
  - LINUX:
 
-`       python fetchFromGoogleCloud.py 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 -o ~/LANDSAT --latest --outputcatalogs /tmp`
+`       fels 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 -o ~/LANDSAT --latest --outputcatalogs /tmp`
 
-`       python fetchFromGoogleCloud.py 44UPU S2 2016-10-01 2016-12-31 -o ~/SENTINEL2 -l --outputcatalogs /tmp`
+`       fels 44UPU S2 2016-10-01 2016-12-31 -o ~/SENTINEL2 -l --outputcatalogs /tmp`
 
  - WINDOWS:
 
-`       python fetchFromGoogleCloud.py 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 -o %TEMP%\LANDSAT --latest --outputcatalogs %TEMP%\LANDSAT`
+`       fels 203031 OLI_TIRS 2015-01-01 2015-06-30 -c 30 -o %TEMP%\LANDSAT --latest --outputcatalogs %TEMP%\LANDSAT`
 
-`       python fetchFromGoogleCloud.py 44UPU S2 2016-10-01 2016-12-31 -o %TEMP%\SENTINEL2 -l --outputcatalogs %TEMP%\SENTINEL2`
+`       fels 44UPU S2 2016-10-01 2016-12-31 -o %TEMP%\SENTINEL2 -l --outputcatalogs %TEMP%\SENTINEL2`
 
 Options:
 

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -107,14 +107,15 @@ def get_landsat_image(url, outputdir, overwrite=False):
     possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF', 'B6.TIF', 'B6_VCID_1.TIF',
                       'B6_VCID_2.TIF', 'B7.TIF', 'B8.TIF', 'B9.TIF', 'BQA.TIF', 'MTL.txt']
     target_path = os.path.join(outputdir, img)
-    if os.path.isdir(target_path) and not overwrite:
-        print(target_path, "exists and --overwrite option was not used. Skipping image download")
-        return
+
     if not os.path.isdir(target_path):
         os.makedirs(target_path)
     for band in possible_bands:
         complete_url = url + "/" + img + "_" + band
         target_file = os.path.join(target_path, img + "_" + band)
+        if os.path.exists(target_file) and not overwrite:
+            print(target_file, "exists and --overwrite option was not used. Skipping image download")
+            continue
         try:
             content = urlopen(complete_url)
         except HTTPError:

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -126,10 +126,16 @@ def get_landsat_image(url, outputdir, overwrite=False):
         except URLError:
             print("Timeout, Restart=======>")
             time.sleep(10)
-            get_landsat_image(url, outputdir, overwrite, sat)
+            get_landsat_image(url, outputdir, overwrite)
             return
         with open(target_file, 'wb') as f:
-            shutil.copyfileobj(content, f)
+            try:
+                shutil.copyfileobj(content, f)
+            except socket.timeout:
+                print("Socket Timeout, Restart=======>")
+                time.sleep(10)
+                get_landsat_image(url, outputdir, overwrite)
+                return
             print("Downloaded", target_file)
 
 

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -4,6 +4,7 @@ import argparse
 import csv
 import datetime
 import os
+import socket
 import sys
 import tempfile
 import time
@@ -103,11 +104,26 @@ def query_sentinel2_catalogue(collection_file, cc_limit, date_start, date_end, t
     return sort_url_list(cc_values, all_acqdates, all_urls)
 
 
-def get_landsat_image(url, outputdir, overwrite=False):
+def get_landsat_image(url, outputdir, overwrite=False, sat="TM"):
     """Download a Landsat image file."""
     img = os.path.basename(url)
-    possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF', 'B6.TIF', 'B6_VCID_1.TIF',
-                      'B6_VCID_2.TIF', 'B7.TIF', 'B8.TIF', 'B9.TIF', 'BQA.TIF', 'MTL.txt']
+    if sat == "TM":
+        possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF',
+                          'B6.TIF', 'B7.TIF', 'GCP.txt', 'VER.txt', 'VER.jpg',
+                          'ANG.txt', 'BQA.TIF', 'MTL.txt']
+    elif sat == "OLI_TIRS":
+        possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF',
+                          'B6.TIF', 'B7.TIF', 'B8.TIF', 'B9.TIF', 'B10.TIF',
+                          "B11.TIF", 'BQA.TIF', 'MTL.txt']
+    elif sat == "ETM":
+        possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF',
+                          'B6.TIF', 'B6_VCID_1.TIF', 'B6_VCID_2.TIF', 'B7.TIF',
+                          'B8.TIF', 'B9.TIF', 'BQA.TIF', 'MTL.txt']
+    else:
+        possible_bands = ['B1.TIF', 'B2.TIF', 'B3.TIF', 'B4.TIF', 'B5.TIF',
+                          'B6.TIF', 'B6_VCID_1.TIF', 'B6_VCID_2.TIF', 'B7.TIF',
+                          'B8.TIF', 'B9.TIF', 'BQA.TIF', 'MTL.txt']
+
     target_path = os.path.join(outputdir, img)
 
     if not os.path.isdir(target_path):
@@ -126,7 +142,7 @@ def get_landsat_image(url, outputdir, overwrite=False):
         except URLError:
             print("Timeout, Restart=======>")
             time.sleep(10)
-            get_landsat_image(url, outputdir, overwrite)
+            get_landsat_image(url, outputdir, overwrite, sat)
             return
         with open(target_file, 'wb') as f:
             try:
@@ -134,7 +150,7 @@ def get_landsat_image(url, outputdir, overwrite=False):
             except socket.timeout:
                 print("Socket Timeout, Restart=======>")
                 time.sleep(10)
-                get_landsat_image(url, outputdir, overwrite)
+                get_landsat_image(url, outputdir, overwrite, sat)
                 return
             print("Downloaded", target_file)
 
@@ -288,7 +304,7 @@ def main():
             for i, u in enumerate(url):
                 if not options.list:
                     print("Downloading {} of {}...".format(i+1, len(url)))
-                    get_landsat_image(u, options.output, options.overwrite)
+                    get_landsat_image(u, options.output, options.overwrite, options.sat)
                 else:
                     print(url[i])
 

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -6,6 +6,7 @@ import datetime
 import os
 import sys
 import tempfile
+import time
 import shutil
 import glob
 import gzip
@@ -13,8 +14,9 @@ import xml.etree.ElementTree as ET
 try:
     from urllib2 import urlopen
     from urllib2 import HTTPError
+    from urllib2 import URLError
 except ImportError:
-    from urllib.request import urlopen, HTTPError
+    from urllib.request import urlopen, HTTPError, URLError
 try:
     from osgeo import gdal
 except ImportError:
@@ -121,6 +123,11 @@ def get_landsat_image(url, outputdir, overwrite=False):
         except HTTPError:
             print("Could not find", band, "band image file.")
             continue
+        except URLError:
+            print("Timeout, Restart=======>")
+            time.sleep(10)
+            get_landsat_image(url, outputdir, overwrite, sat)
+            return
         with open(target_file, 'wb') as f:
             shutil.copyfileobj(content, f)
             print("Downloaded", target_file)

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -135,7 +135,7 @@ def get_landsat_image(url, outputdir, overwrite=False, sat="TM"):
             print(target_file, "exists and --overwrite option was not used. Skipping image download")
             continue
         try:
-            content = urlopen(complete_url)
+            content = urlopen(complete_url, timeout=600)
         except HTTPError:
             print("Could not find", band, "band image file.")
             continue


### PR DESCRIPTION
When the internet speed is unstable, the tool may just create a folder and
then interrupt. When I run the tool again, it will skip some images not fully
downloaded because the tool think having a folder is equivalent to having an
image. So I believe that we should not use the folder to determine if the
image is downloaded.