### PR TITLE
Cleanup formatting. Remove import stars

### DIFF
--- a/fels/__init__.py
+++ b/fels/__init__.py
@@ -14,10 +14,27 @@
 # limitations under the License.
 # =============================================================================================
 
-if __name__ == '__main__':
-    import os
-    home = os.path.expanduser('~')
+__dev__ = """
+# Command to autogenerate this init file
+mkinit -m fels --relative -w
+"""
+from . import fels
+from . import landsat
+from . import sentinel2
+from . import utils
 
-from . import utils, sentinel2, landsat
-from .fels import *
-# ========================= EOF ====================================================================
+from .fels import (convert_wkt_to_scene, get_parser, main, run_fels,)
+from .landsat import (get_landsat_image, landsatdir_to_date,
+                      query_landsat_catalogue,)
+from .sentinel2 import (check_full_tile, get_S2_INSPIRE_title,
+                        get_S2_image_bands, get_sentinel2_image, is_new,
+                        query_sentinel2_catalogue, safedir_to_datetime,)
+from .utils import (download_file, download_metadata_file, sort_url_list,)
+
+__all__ = ['check_full_tile', 'convert_wkt_to_scene', 'download_file',
+           'download_metadata_file', 'fels', 'get_S2_INSPIRE_title',
+           'get_S2_image_bands', 'get_landsat_image', 'get_parser',
+           'get_sentinel2_image', 'is_new', 'landsat', 'landsatdir_to_date',
+           'main', 'query_landsat_catalogue', 'query_sentinel2_catalogue',
+           'run_fels', 'safedir_to_datetime', 'sentinel2', 'sort_url_list',
+           'utils']

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -5,11 +5,10 @@ import datetime
 import os
 import json
 import pkg_resources
-from fels.utils import *
-from fels.landsat import *
-from fels.sentinel2 import *
+from fels.utils import download_metadata_file
+from fels.landsat import get_landsat_image, query_landsat_catalogue, landsatdir_to_date
+from fels.sentinel2 import query_sentinel2_catalogue, get_sentinel2_image, safedir_to_datetime
 import geopandas
-import json
 import shapely as shp
 
 
@@ -109,7 +108,7 @@ def run_fels(*args, **kwargs):
 
     assert len(args) == 4
     scene, sat, start_date, end_date = args
-    
+
     # fix alternate args
 
     if isinstance(scene, tuple):
@@ -123,7 +122,7 @@ def run_fels(*args, **kwargs):
             }
     if sat in landsats:
         sat = landsats[sat]
-    
+
     if isinstance(end_date, datetime.date):
         end_date = end_date.strftime('%Y-%m-%d')
     if isinstance(start_date, datetime.date):
@@ -182,12 +181,12 @@ def _run_fels(options):
                 if not options.list:
                     valid_mask = []
                     for i, u in enumerate(url):
-                        print("Downloading {} of {}...".format(i+1, len(url)))
+                        print("Downloading {} of {}...".format(i + 1, len(url)))
                         ok = get_sentinel2_image(u, options.output, options.overwrite, options.excludepartial, options.noinspire, options.reject_old)
                         if not ok:
                             print(f'Skipped {u}')
                         valid_mask.append(ok)
-                    url = [u for u,m in zip(url, valid_mask) if m]
+                    url = [u for u, m in zip(url, valid_mask) if m]
         else:
             landsat_metadata_file = download_metadata_file(LANDSAT_METADATA_URL, options.outputcatalogs, 'Landsat')
             url = query_landsat_catalogue(landsat_metadata_file, options.cloudcover, options.start_date,
@@ -199,7 +198,7 @@ def _run_fels(options):
                 print("Found {} files.".format(len(url)))
                 for i, u in enumerate(url):
                     if not options.list:
-                        print("Downloading {} of {}...".format(i+1, len(url)))
+                        print("Downloading {} of {}...".format(i + 1, len(url)))
                         get_landsat_image(u, options.output, options.overwrite, options.sat)
 
         if options.dates:
@@ -216,5 +215,7 @@ def _run_fels(options):
             result.extend(url)
 
     return result
+
+
 if __name__ == "__main__":
     main()

--- a/fels/landsat.py
+++ b/fels/landsat.py
@@ -12,8 +12,7 @@ try:
 except ImportError:
     from urllib.request import urlopen, HTTPError, URLError
 
-
-from fels.utils import *
+from fels.utils import sort_url_list
 
 
 def query_landsat_catalogue(collection_file, cc_limit, date_start, date_end, wr2path, wr2row,
@@ -40,6 +39,7 @@ def query_landsat_catalogue(collection_file, cc_limit, date_start, date_end, wr2
     if latest and all_urls:
         return [sort_url_list(cc_values, all_acqdates, all_urls).pop()]
     return sort_url_list(cc_values, all_acqdates, all_urls)
+
 
 def get_landsat_image(url, outputdir, overwrite=False, sat="TM"):
     """Download a Landsat image file."""
@@ -97,7 +97,7 @@ def landsatdir_to_date(string, processing=False):
         >>> from datetime import date
         >>> s = 'LE07_L1GT_115034_20160707_20161009_01_T2'
         >>> d = landsatdir_to_date(s)
-        >>> assert d == date(2016, 07, 07)
+        >>> assert d == date(2016, 7, 7)
 
     References:
         https://github.com/dgketchum/Landsat578#-1
@@ -108,4 +108,3 @@ def landsatdir_to_date(string, processing=False):
         d_str = string.split('_')[4]  # this is the processing date
     d = list(map(int, [d_str[:4], d_str[4:6], d_str[6:]]))
     return datetime.date(*d)
-

--- a/fels/utils.py
+++ b/fels/utils.py
@@ -5,10 +5,8 @@ import gzip
 import requests
 try:
     from urllib2 import urlopen
-    from urllib2 import HTTPError
-    from urllib2 import URLError
 except ImportError:
-    from urllib.request import urlopen, HTTPError, URLError
+    from urllib.request import urlopen
 
 
 def download_metadata_file(url, outputdir, program):

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,3 @@ setup(
     install_requires=['numpy', 'requests', 'shapely', 'geopandas',],
     dependency_links=['https://www.conan.io/source/Gdal/2.1.3/osechet/stable'],
     **setup_kwargs)
-


### PR DESCRIPTION
This PR has almost no functionality change. It cleans up some of the formatting and replaces the implicit `import *`'s with explicit import statements, so it is always clear where functions are being imported from.

To remove the `import *`'s I manually imported the used functions in each of the submodules. However, in the `__init__.py` file, we still want to expose all functions to the user. To help with this I used the (pip installable) [mkinit](https://github.com/Erotemic/mkinit) program to auto-generate the explicit `__init__.py` file.

Other changes include minor pep8 spacing changes, and removal of duplicate or unused imports.

There was an issue in a doctest where `07, 07` is not valid syntax, so I fixed that. I also added an `# xdoctest: +SKIP` directive to a test that fails because it does not ensure that a required file exists. That should probably be fixed in a separate PR, and I added a TODO note.

Lastly, when running the doctests, I noticed that the import time was rather large. It took 3 seconds to just import the module. I profiled by running with `python -x importtime -c "import fels"` and discovered that `gdal` is the culprit. It looks like gdal is only used in one very specific place, and only if a "partial" flag is set, so in many cases the user might not even need gdal, but still be forced to incur the 3 second overhead because it is a global import. To mitigate this, I moved `from osgeo import gdal` into the function where it was used. This does incur the trade off that if gdal is not installed and the user does want it, the error is delayed until the function is called, but I think the improved import time is worth it.

There are a few other things I'd like to tweak in this tool, but I find `import *` really difficult to work with, so I wanted to submit a somewhat minimal PR that handle that before I tackled other things.
