### PR TITLE
Add tests, fixed a bug, use pytest on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,10 @@ jobs:
         ls -al
         mkdir -p tmpdir
         cd tmpdir
-        xdoctest -m fels
+        #xdoctest -m fels
+        FELS_INSTALL_DIR=$(python -c "import fels, os; print(os.path.dirname(fels.__file__))")
+        echo "FELS_INSTALL_DIR = $FELS_INSTALL_DIR"
+        pytest --verbose --xdoctest --cov-report term --cov=fels ../tests $FELS_INSTALL_DIR
 
     - name: Upload Wheel artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,9 +37,9 @@ jobs:
         python-version: 3.8
     - name: Upgrade pip 
       run: |
+        python -m pip install --upgrade pip wheel
         python -m pip install -r requirements/build.txt
         python -m pip install -r requirements/tests.txt
-        python -m pip install --upgrade pip wheel
     - name: Build Wheel
       run: |
         python setup.py bdist_wheel
@@ -57,7 +57,7 @@ jobs:
         #xdoctest -m fels
         FELS_INSTALL_DIR=$(python -c "import fels, os; print(os.path.dirname(fels.__file__))")
         echo "FELS_INSTALL_DIR = $FELS_INSTALL_DIR"
-        pytest --verbose --xdoctest --cov-report term --cov=fels ../tests $FELS_INSTALL_DIR -s
+        pytest --verbose --xdoctest --cov-report term --cov=fels ../tests $FELS_INSTALL_DIR
 
     - name: Upload Wheel artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         #xdoctest -m fels
         FELS_INSTALL_DIR=$(python -c "import fels, os; print(os.path.dirname(fels.__file__))")
         echo "FELS_INSTALL_DIR = $FELS_INSTALL_DIR"
-        pytest --verbose --xdoctest --cov-report term --cov=fels ../tests $FELS_INSTALL_DIR
+        pytest --verbose --xdoctest --cov-report term --cov=fels ../tests $FELS_INSTALL_DIR -s
 
     - name: Upload Wheel artifact
       uses: actions/upload-artifact@v2

--- a/fels/fels.py
+++ b/fels/fels.py
@@ -138,7 +138,7 @@ def get_parser():
     parser.add_argument('-l', '--list', help='List available download urls and exit without downloading', action='store_true', default=False)
     parser.add_argument('-d', '--dates', help='List or return dates instead of download urls', action='store_true', default=False)
     parser.add_argument('-r', '--reject_old', help='For S2, skip redundant old-format (before Nov 2016) images', action='store_true', default=False)
-    parser.add_argument('-t', '--thresh', help='Only select intersecting areas where the fraction of the tile that overlaps with the spatial region is greater than this threshol', default=0.0)
+    parser.add_argument('-t', '--thresh', help='Only select intersecting areas where the fraction of the tile that overlaps with the spatial region is greater than this threshold', default=0.0)
     parser.add_argument('--use_csv', action='store_true', dest='use_csv', help='use the direct csv query instead of sqlite3 (only useful if you are doing 1 query for the first time)')
     parser.add_argument('--version', action='version', version='{version}'.format(**version_info))
     return parser
@@ -223,7 +223,6 @@ def _get_options(*args, **kwargs):
             scene = str(scene[0]).zfill(3) + str(scene[1]).zfill(3)
         kwargs['scene'] = scene
 
-    print('start_date = {!r}'.format(start_date))
     if isinstance(end_date, datetime.date):
         end_date = kwargs['end_date'] = datetime.date.isoformat(end_date)
     if isinstance(start_date, datetime.date):
@@ -241,7 +240,6 @@ def _get_options(*args, **kwargs):
 
     kwargs['sat'] = sat
 
-    print('start_date = {!r}'.format(start_date))
     defaults = get_parser().parse_args([scene, sat, start_date, end_date])
 
     # overwrite with user-defined kwargs
@@ -341,7 +339,7 @@ def _run_fels(options):
             dirs = [u.split('/')[-1] for u in url]
             if options.sat == 'S2':
                 datetimes = [safedir_to_datetime(d) for d in dirs]
-                dates = [dt.dates() for dt in datetimes]
+                dates = [dt.date() for dt in datetimes]
             else:
                 dates = [landsatdir_to_date(d) for d in dirs]
 

--- a/fels/utils.py
+++ b/fels/utils.py
@@ -22,18 +22,19 @@ def download_metadata_file(url, outputdir, program):
     if outputdir is None:
         outputdir = FELS_DEFAULT_OUTPUTDIR
     zipped_index_path = os.path.join(outputdir, 'index_' + program + '.csv.gz')
-    if not os.path.isfile(zipped_index_path):
-        if not os.path.exists(os.path.dirname(zipped_index_path)):
-            os.makedirs(os.path.dirname(zipped_index_path))
-        print('Downloading Metadata file...')
-        print('url = {!r}'.format(url))
-        print('outputdir = {!r}'.format(outputdir))
-        ubelt.download(url, fpath=zipped_index_path, chunksize=int(2 ** 22))
     index_path = os.path.join(outputdir, 'index_' + program + '.csv')
     if not os.path.isfile(index_path):
+        if not os.path.isfile(zipped_index_path):
+            if not os.path.exists(os.path.dirname(zipped_index_path)):
+                os.makedirs(os.path.dirname(zipped_index_path))
+            print('Downloading Metadata file...')
+            print('url = {!r}'.format(url))
+            print('outputdir = {!r}'.format(outputdir))
+            ubelt.download(url, fpath=zipped_index_path, chunksize=int(2 ** 22))
         print('Unzipping Metadata file...')
         with gzip.open(zipped_index_path) as gzip_index, open(index_path, 'wb') as f:
             shutil.copyfileobj(gzip_index, f)
+        ubelt.delete(zipped_index_path)  # remove archive file
     return index_path
 
 

--- a/fels/utils.py
+++ b/fels/utils.py
@@ -150,6 +150,8 @@ def ensure_sqlite_csv_conn(collection_file, fields, table_create_cmd,
                 for line in prog:
                     cols = line[:-1].split(',')
                     # Select the values to insert into the SQLite database
+                    # Note: if this fails with an index error, its possible
+                    # the CSV file was not fully downloaded
                     vals = [cols[idx] for idx in col_indexes]
                     cur.execute(insert_statement, vals)
 

--- a/tests/test_query_consistency.py
+++ b/tests/test_query_consistency.py
@@ -3,7 +3,6 @@
 Test that the python API and CLI return the same results for equivalent queries
 """
 import json
-import os
 import ubelt as ub
 import datetime
 import fels
@@ -18,7 +17,9 @@ def _run_consistency_test(sensor,
                           expected_urls,
                           expected_dates
                           ):
-    outputcatalogs = os.path.expanduser('~/data/fels/')
+    from fels.utils import FELS_DEFAULT_OUTPUTDIR
+    outputcatalogs = FELS_DEFAULT_OUTPUTDIR
+
     start_date_iso = start_date.isoformat()
     end_date_iso = end_date.isoformat()
     wkt_geometry = geometry.shape(geojson_geom).wkt
@@ -28,19 +29,20 @@ def _run_consistency_test(sensor,
     # Test python invocation
     python_result1 = fels.run_fels(
         None, sensor, start_date_iso, end_date_iso, cloudcover=cloudcover,
-        output='.', geometry=wkt_geometry, latest=True, list=True,
-        outputcatalogs=outputcatalogs)
+        outputcatalogs=outputcatalogs,
+        output='.', geometry=wkt_geometry, latest=True, list=True)
 
     # python with friendly aliases
     python_result2 = fels.run_fels(
         None, sensor_alias, start_date, end_date, cloudcover=cloudcover,
-        output='.', geometry=geojson_geom, latest=True, list=True,
-        outputcatalogs=outputcatalogs)
+        outputcatalogs=outputcatalogs,
+        output='.', geometry=geojson_geom, latest=True, list=True)
 
     python_dates_result = fels.run_fels(
         None, sensor_alias, start_date, end_date, cloudcover=cloudcover,
+        outputcatalogs=outputcatalogs,
         output='.', geometry=geojson_geom, latest=True, dates=True,
-        list=True, outputcatalogs=outputcatalogs)
+        list=True)
 
     assert python_dates_result == expected_dates
     assert len(python_result1) == len(expected_urls), (
@@ -50,7 +52,8 @@ def _run_consistency_test(sensor,
     fmtdict = dict(
         sensor=sensor, sensor_alias=sensor_alias,
         start_date_iso=start_date_iso, end_date_iso=end_date_iso,
-        cloudcover=cloudcover, outputcatalogs=outputcatalogs)
+        outputcatalogs=outputcatalogs,
+        cloudcover=cloudcover)
 
     # Test CLI invocation
     fmtdict1 = fmtdict.copy()
@@ -90,12 +93,12 @@ def test_query_consistency_l8():
     geojson_geom = {'type': 'Point', 'coordinates': [-105.2705, 40.015]}
 
     expected_urls = [
-        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/034/032/LC08_L1TP_034032_20150619_20170226_01_T1',
-        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/033/032/LC08_L1TP_033032_20150308_20170301_01_T1'
+        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/034/032/LC08_L1TP_034032_20150603_20170226_01_T1',
+        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/033/032/LC08_L1TP_033032_20150527_20170301_01_T1'
     ]
     expected_dates = [
-        datetime.date(2015, 6, 19),
-        datetime.date(2015, 3, 8)
+        datetime.date(2015, 6, 3),
+        datetime.date(2015, 5, 27)
     ]
     _run_consistency_test(sensor, sensor_alias, start_date, end_date,
                           geojson_geom, expected_urls, expected_dates)
@@ -113,10 +116,10 @@ def test_query_consistency_s2():
     geojson_geom = {'type': 'Point', 'coordinates': [-105.2705, 40.015]}
 
     expected_urls = [
-        'http://storage.googleapis.com/gcp-public-data-sentinel-2/tiles/13/T/DE/S2A_MSIL1C_20180517T175051_N0206_R141_T13TDE_20180517T212632.SAFE',
+        'http://storage.googleapis.com/gcp-public-data-sentinel-2/tiles/13/T/DE/S2A_MSIL1C_20180104T175251_N0206_R098_T13TDE_20180104T191930.SAFE',
     ]
     expected_dates = [
-        datetime.date(2018, 5, 17)
+        datetime.date(2018, 1, 4)
     ]
     _run_consistency_test(sensor, sensor_alias, start_date, end_date,
                           geojson_geom, expected_urls, expected_dates)

--- a/tests/test_query_consistency.py
+++ b/tests/test_query_consistency.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+"""
+Test that the python API and CLI return the same results for equivalent queries
+"""
+import json
+import os
+import shapely as shp
+import ubelt as ub
+import datetime
+import fels
+
+
+def _run_consistency_test(sensor,
+                          sensor_alias,
+                          start_date,
+                          end_date,
+                          geojson_geom,
+                          expected_urls,
+                          expected_dates
+                          ):
+    outputcatalogs = os.path.expanduser('~/data/fels/')
+    start_date_iso = start_date.isoformat()
+    end_date_iso = end_date.isoformat()
+    wkt_geometry = shp.geometry.shape(geojson_geom).to_wkt()
+    geojson_geom_text = json.dumps(geojson_geom)
+    cloudcover = 30
+
+    # Test python invocation
+    python_result1 = fels.run_fels(
+        None, sensor, start_date_iso, end_date_iso, cloudcover=cloudcover,
+        output='.', geometry=wkt_geometry, latest=True, list=True,
+        outputcatalogs=outputcatalogs)
+
+    # python with friendly aliases
+    python_result2 = fels.run_fels(
+        None, sensor_alias, start_date, end_date, cloudcover=cloudcover,
+        output='.', geometry=geojson_geom, latest=True, list=True,
+        outputcatalogs=outputcatalogs)
+
+    python_dates_result = fels.run_fels(
+        None, sensor_alias, start_date, end_date, cloudcover=cloudcover,
+        output='.', geometry=geojson_geom, latest=True, dates=True,
+        list=True, outputcatalogs=outputcatalogs)
+
+    assert python_dates_result == expected_dates
+    assert len(python_result1) == len(expected_urls), (
+        'we expect {} results'.format(len(expected_urls)))
+    assert python_result1 == python_result2
+
+    fmtdict = dict(
+        sensor=sensor, sensor_alias=sensor_alias,
+        start_date_iso=start_date_iso, end_date_iso=end_date_iso,
+        cloudcover=cloudcover, outputcatalogs=outputcatalogs)
+
+    # Test CLI invocation
+    fmtdict1 = fmtdict.copy()
+    fmtdict1['geometry'] = wkt_geometry
+    cli_result1 = ub.cmd(ub.paragraph(
+        '''
+        fels {sensor} {start_date_iso} {end_date_iso} -c {cloudcover} -o .
+        -g '{geometry}' --latest --list --outputcatalogs {outputcatalogs}
+        ''').format(**fmtdict1), verbose=3)
+
+    # The last lines of the CLI output should be our expected results
+    results = cli_result1['out'].strip().split('\n')[-(len(expected_urls) + 1):]
+    assert not results[0].startswith('http')
+    assert results[1:] == expected_urls
+
+    fmtdict2 = fmtdict.copy()
+    fmtdict2['geometry'] = geojson_geom_text
+    cli_result2 = ub.cmd(ub.paragraph(
+        '''
+        fels {sensor_alias} {start_date_iso} {end_date_iso} -c {cloudcover} -o .
+        -g '{geometry}' --latest --list --outputcatalogs {outputcatalogs}
+        ''').format(**fmtdict2), verbose=3)
+    # The last lines of the CLI output should be our expected results
+    results = cli_result2['out'].strip().split('\n')[-(len(expected_urls) + 1):]
+    assert not results[0].startswith('http')
+    assert results[1:] == expected_urls
+
+
+def test_query_consistency_l8():
+    """
+    Test an L8 invocation
+    """
+    sensor = 'OLI_TIRS'
+    sensor_alias = 'L8'
+    start_date = datetime.date(2015, 1, 1)
+    end_date = datetime.date(2015, 6, 30)
+    geojson_geom = {'type': 'Point', 'coordinates': [-105.2705, 40.015]}
+
+    expected_urls = [
+        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/034/032/LC08_L1TP_034032_20150619_20170226_01_T1',
+        'http://storage.googleapis.com/gcp-public-data-landsat/LC08/01/033/032/LC08_L1TP_033032_20150308_20170301_01_T1'
+    ]
+    expected_dates = [
+        datetime.date(2015, 6, 19),
+        datetime.date(2015, 3, 8)
+    ]
+    _run_consistency_test(sensor, sensor_alias, start_date, end_date,
+                          geojson_geom, expected_urls, expected_dates)
+
+
+def test_query_consistency_s2():
+    """
+    Test an S2 invocation
+    """
+    # Define variations of a test query and the results we expect from it
+    sensor = 'S2'
+    sensor_alias = 'S2'
+    start_date = datetime.date(2018, 1, 1)
+    end_date = datetime.date(2018, 6, 30)
+    geojson_geom = {'type': 'Point', 'coordinates': [-105.2705, 40.015]}
+
+    expected_urls = [
+        'http://storage.googleapis.com/gcp-public-data-sentinel-2/tiles/13/T/DE/S2A_MSIL1C_20180517T175051_N0206_R141_T13TDE_20180517T212632.SAFE',
+    ]
+    expected_dates = [
+        datetime.date(2018, 5, 17)
+    ]
+    _run_consistency_test(sensor, sensor_alias, start_date, end_date,
+                          geojson_geom, expected_urls, expected_dates)

--- a/tests/test_query_consistency.py
+++ b/tests/test_query_consistency.py
@@ -4,10 +4,10 @@ Test that the python API and CLI return the same results for equivalent queries
 """
 import json
 import os
-import shapely as shp
 import ubelt as ub
 import datetime
 import fels
+from shapely import geometry
 
 
 def _run_consistency_test(sensor,
@@ -21,7 +21,7 @@ def _run_consistency_test(sensor,
     outputcatalogs = os.path.expanduser('~/data/fels/')
     start_date_iso = start_date.isoformat()
     end_date_iso = end_date.isoformat()
-    wkt_geometry = shp.geometry.shape(geojson_geom).to_wkt()
+    wkt_geometry = geometry.shape(geojson_geom).wkt
     geojson_geom_text = json.dumps(geojson_geom)
     cloudcover = 30
 


### PR DESCRIPTION
Adds a unit test to verify that the commands in the README really do produce the same results.

While writing this test I found a small bug when `--dates` is given to S2, there was a typo in the method name. 

Also fixed a typo in the help strings.

Lastly, the CI now runs with pytest instead of just xdoctest. This makes it easier to combine doctests and unit tests. Coverage on my local machine is:

```
----------- coverage: platform linux, python 3.8.6-final-0 -----------
Name                                                                        Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/__init__.py        9      0   100%
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/__main__.py        4      1    75%
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/fels.py          160     19    88%
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/landsat.py       107     42    61%
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/sentinel2.py     187    126    33%
/home/joncrall/code/fetchLandsatSentinelFromGoogleCloud/fels/utils.py         111     62    44%
-----------------------------------------------------------------------------------------------
TOTAL                                                                         578    250    57%
```

Should be roughly the same on the CI.